### PR TITLE
Correct the unit of time used in the HTTP logger

### DIFF
--- a/loggers/HTTP_Logger.php
+++ b/loggers/HTTP_Logger.php
@@ -63,7 +63,7 @@
                  '_url' => $url,
              ];
 
-         $this->debug("http_api_debug: '{request_method}' request to '{url}' (took {time_taken} ms)", $context);
+         $this->debug("http_api_debug: '{request_method}' request to '{url}' (took {time_taken} s)", $context);
 
      }
 


### PR DESCRIPTION
The time taken is in seconds, not milliseconds.
